### PR TITLE
Add cpExtra escape hatch to ContactProperties

### DIFF
--- a/loops.cabal
+++ b/loops.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               loops
-version:            0.3.0.0
+version:            0.4.0.0
 license:            MIT
 license-file:       LICENSE
 author:             Familiar Publishing

--- a/src/Loops.hs
+++ b/src/Loops.hs
@@ -74,27 +74,29 @@ import qualified Data.Text as T
 import GHC.Generics (Generic)
 import Internal.Loops
 
--- | Represents contact properties that can be updated when sending an event
-data ContactProperties = ContactProperties
-    { cpFirstName :: Maybe Text
-    , cpLastName :: Maybe Text
-    , cpSubscribed :: Maybe Bool
-    , cpUserGroup :: Maybe Text
-    -- Add more contact properties as needed
-    }
-    deriving (Show, Eq, Generic)
+{- | Contact properties to update when sending an event.
+
+Loops recognises the standard property names (@firstName@, @lastName@,
+@subscribed@, @userGroup@, @source@) and updates the contact's default
+fields; any other key is stored as a custom contact property. The SDK
+does not duplicate the standard fields as typed record fields — callers
+build an 'Object' directly so the wire payload matches what Loops expects.
+
+Example:
+
+@
+ContactProperties $ KM.fromList
+  [ (\"subscribed\", Bool True)
+  , (\"userGroup\", String \"Administrator\")
+  , (\"organizationKind\", String \"PublisherOrg\")
+  ]
+@
+-}
+newtype ContactProperties = ContactProperties Object
+    deriving (Show, Eq)
 
 instance ToJSON ContactProperties where
-    toJSON =
-        genericToJSON
-            defaultOptions
-                { fieldLabelModifier = drop 2 -- Remove 'cp' prefix
-                }
-    toEncoding =
-        genericToEncoding
-            defaultOptions
-                { fieldLabelModifier = drop 2 -- Remove 'cp' prefix
-                }
+    toJSON (ContactProperties o) = Object o
 
 -- | Represents event-specific properties
 data EventProperties = EventProperties
@@ -227,10 +229,10 @@ sendEvent client eventName mEmail mUserId mContactProps mEventProps mMailingList
     let basePayload = ["eventName" .= eventName]
 
         contactPayload = case mContactProps of
-            Just props -> case toJSON props of
-                Object o -> map (\(k, v) -> (k, v)) (KM.toList o)
-                _ -> []
-            Nothing -> []
+            Just (ContactProperties o)
+                | not (KM.null o) ->
+                    ["contactProperties" .= Object o]
+            _ -> []
 
         eventPayload = ["eventProperties" .= mEventProps | isJust mEventProps]
 

--- a/test/LoopsSpec.hs
+++ b/test/LoopsSpec.hs
@@ -54,6 +54,21 @@ main = hspec $ do
                         ]
             toJSON email `shouldBe` expected
 
+        it "ContactProperties encodes as the underlying JSON object" $ do
+            let props =
+                    ContactProperties $
+                        KM.fromList
+                            [ (K.fromText "subscribed", Bool False)
+                            , (K.fromText "userGroup", String "Administrator")
+                            , (K.fromText "organizationKind", String "PublisherOrg")
+                            ]
+            toJSON props
+                `shouldBe` object
+                    [ "subscribed" .= False
+                    , "userGroup" .= ("Administrator" :: Text)
+                    , "organizationKind" .= ("PublisherOrg" :: Text)
+                    ]
+
         it "omits attachments key when list is empty" $ do
             let email :: LoopsEmail (KM.KeyMap Value)
                 email =


### PR DESCRIPTION
Lets callers attach arbitrary custom contact properties (beyond firstName/lastName/subscribed/userGroup) to sendEvent without having to extend the SDK for every new field. Extra keys are merged flat into the top-level JSON object, and Nothing-valued typed fields are now omitted instead of serialised as null.

# Pull Request

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. Add screenshots to help describe the problem or your solution.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

Before you submit this PR, please check off items you have completed:

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context or screenshots about the pull request here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contact properties now accept and preserve arbitrary extra custom fields and are emitted as a dedicated contactProperties object in payloads.

* **Chores**
  * Package version bumped to 0.4.0.0.
  * Simplified JSON serialization for contact properties (explicitly emits the provided object).

* **Tests**
  * Added test coverage validating ContactProperties JSON encoding with extra properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->